### PR TITLE
Fix `waf` generation of `compile_commands.json`

### DIFF
--- a/waftools/clang_compilation_database.py
+++ b/waftools/clang_compilation_database.py
@@ -43,11 +43,14 @@ def write_compilation_database(ctx):
         "Write the clang compilation database as json"
         database_file = ctx.bldnode.make_node('compile_commands.json')
         file_path = str(database_file.path_from(ctx.path))
+
         if not os.path.exists(file_path):
             with open(file_path, 'w') as f:
                 f.write('[]')
+
         Logs.info("Store compile comands in %s" % file_path)
         clang_db = dict((x["file"], x) for x in json.load(database_file))
+
         for task in getattr(ctx, 'clang_compilation_database_tasks', []):
                 # we need only to generate last_cmd, so override
                 # exec_command temporarily
@@ -66,8 +69,8 @@ def write_compilation_database(ctx):
                 filename = task.inputs[0].abspath()
                 entry = {
                         "directory" : getattr(task, 'cwd', ctx.variant_dir),
-                        "arguments"   : arguments,
-                        "file"    : filename,
+                        "arguments" : arguments,
+                        "file"      : filename,
                 }
                 clang_db[filename] = entry
         database_file.write_json(list(clang_db.values()))

--- a/waftools/clang_compilation_database.py
+++ b/waftools/clang_compilation_database.py
@@ -49,18 +49,28 @@ def write_compilation_database(ctx):
         Logs.info("Store compile comands in %s" % file_path)
         clang_db = dict((x["file"], x) for x in json.load(database_file))
         for task in getattr(ctx, 'clang_compilation_database_tasks', []):
+                # we need only to generate last_cmd, so override
+                # exec_command temporarily
+                def exec_command(self, *k, **kw):
+                    return 0
+                old_exec = task.exec_command
+                task.exec_command = exec_command
+                task.run()
+                task.exec_command = old_exec
+
                 try:
-                        cmd = task.last_cmd
+                        arguments = task.last_cmd
                 except AttributeError:
                         continue
+
                 filename = task.inputs[0].abspath()
                 entry = {
                         "directory" : getattr(task, 'cwd', ctx.variant_dir),
-                        "command"   : " ".join(cmd),
+                        "arguments"   : arguments,
                         "file"    : filename,
                 }
                 clang_db[filename] = entry
-        database_file.write(json.dumps(clang_db.values(), indent=2))
+        database_file.write_json(list(clang_db.values()))
 
 
 def options(opt):


### PR DESCRIPTION
Fix `waf` generation of `compile_commands.json` when the `--compile_commands` config option is specified.

I've adapted the workaround already used in `sdk/waf/waflib/extras/clang_compilation_database.py` (the `write_compilation_database` method of the `ClangDbContext` class), which runs each `task` with a temporarily disabled `exec_command` in order to obtain the task's `last_cmd`.

When generating the `compile_commands.json` the `commands` field has been replaced with `arguments`, since the [database documentation](https://clang.llvm.org/docs/JSONCompilationDatabase.html) mentions that it is preferred. 

> Either arguments or command is required. arguments is preferred, as shell (un)escaping is a possible source of errors.

Tested on Fedora 41, in VSCode, using the following `c_cpp_properties.json`:
```json
{
    "configurations": [
        {
            "name": "Linux",
            "compilerPath": "/home/bogdan/Programs/arm-gnu-toolchain-13.2.Rel1-x86_64-arm-none-eabi/bin/arm-none-eabi-gcc",
            "compileCommands": [
                "${workspaceFolder}/compile_commands.json"
            ],
            "cStandard": "c17",
            "cppStandard": "c++17",
            "intelliSenseMode": "gcc-arm"
        }
    ],
    "version": 4
}
```