### PR TITLE
ci: enable gitlint

### DIFF
--- a/.github/workflows/gitlint.yml
+++ b/.github/workflows/gitlint.yml
@@ -1,0 +1,20 @@
+name: Lint Git Commits 
+
+on:
+  pull_request: {}
+
+jobs:
+  lint:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+
+      - name: Install GitLint
+        run: pip install gitlint
+
+      - name: Run GitLint 
+        run: gitlint --commits "${{ github.event.pull_request.base.sha }}..HEAD"

--- a/.gitlint
+++ b/.gitlint
@@ -1,0 +1,2 @@
+[general]
+contrib=CT1,CC1,CC2


### PR DESCRIPTION
Applied rules:

- Built-in rulles: all defaults
- Contrib rules:

  - CT1: see https://www.conventionalcommits.org
  - CC1: require Signed-off-by (DCO)
  - CC2: no cleanup commits (fixup! etc.)

Probably the most controversial bit is CT1. If not adopted, certain formatting should be taken to make things consistent.

Ref. https://jorisroovers.com/gitlint/latest/rules/